### PR TITLE
http --> https for API request

### DIFF
--- a/R/wondr.r
+++ b/R/wondr.r
@@ -57,7 +57,7 @@ make_query <- function(wobj, database_id) {
   query <- XML::saveXML(list_to_xml(wobj, "request-parameters"),
                    indent=FALSE,
                    prefix='<?xml version="1.0" encoding="utf-8"?>')
-  res <- httr::POST(sprintf("http://wonder.cdc.gov/controller/datarequest/%s", database_id),
+  res <- httr::POST(sprintf("https://wonder.cdc.gov/controller/datarequest/%s", database_id),
               body=list(request_xml=query),
               encode = "form")
   httr::stop_for_status(res)


### PR DESCRIPTION
From the [CDC WONDER API for Data Query Web Service](https://wonder.cdc.gov/wonder/help/WONDER-API.html) documentation:

> Please note that, like other CDC websites, the WONDER website now uses https, so be sure to use that in the url to access the API.

Without this change, `make_query()` returns `Error: Internal Server Error (HTTP 500).`